### PR TITLE
Remove iOS and Android from built platforms before building.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -113,8 +113,11 @@ echo "Installing meteor" | indent
 
 # Using different folder to prevent install script form deleting packages file
 VENDORED_METEOR="$(mktmpdir meteor)"
-curl https://install.meteor.com | HOME="$VENDORED_METEOR" /bin/sh | indent
+curl -# https://install.meteor.com | HOME="$VENDORED_METEOR" /bin/sh | indent
 echo "Meteor installed" | indent
+
+echo "Ignoring build of mobile platforms"
+sed -i '/^ios$/d;/^android$/d' ./.meteor/platforms
 
 echo "Building meteor bundle" | indent
 mkdir -p "$METEOR_BUILD_DIR"/app


### PR DESCRIPTION
When iOS or Android are included in the .meteor/platforms file, the meteor build command requires the --server option and will fail without it. Given that building for mobile on Bluemix doesn't make sense (that I can think of at the moment), we remove them from .meteor/platforms prior to building.