### PR TITLE
Changed ROOT_URL env to use HTTPS

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -140,7 +140,7 @@ mkdir -p "$BUILD_DIR"/.profile.d
 cat | tee "$BUILD_DIR"/.profile.d/mongo.sh <<EOF
   #!/bin/sh
 
-  export ROOT_URL=\${ROOT_URL:-`ruby -e 'require "json"; puts "http://#{JSON.parse(ENV["VCAP_APPLICATION"])["application_uris"][0]}"'`}
+  export ROOT_URL=\${ROOT_URL:-`ruby -e 'require "json"; puts "https://#{JSON.parse(ENV["VCAP_APPLICATION"])["application_uris"][0]}"'`}
   export MONGO_URL=\${MONGO_URL:-`ruby -e "require 'json'; puts JSON.parse(ENV['VCAP_SERVICES']).find { |key,value| value[0]['label'].include? 'mongolab' }[1][0]['credentials']['uri']"`}
   export
 EOF


### PR DESCRIPTION
Most OAUTH providers require an HTTPS URL for a callback.  The default Meteor OAUTH client uses the ROOL_URL to build the callback URL.